### PR TITLE
Fix docstring in io.parsers:read_header

### DIFF
--- a/metacsv/io/parsers.py
+++ b/metacsv/io/parsers.py
@@ -103,9 +103,9 @@ def read_header(fp, header_file=None, parse_vars=False, assertions=None, *args, 
         assertions (dict-like): dictionary of values to assert in file header
 
     Returns:
-        args        
-        variables   
+        attrs        
         coords      
+        variables      
 
     Example:
 


### PR DESCRIPTION
- [x] closes #23 
- [ ] tests added / passed
- [x] passes ``git diff upstream/master | flake8 --diff``
- [ ] whatsnew entry

Replaces pull #23 with clean diff